### PR TITLE
Versioning feature pat

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,10 @@ utility.debug('App route has been hit.', 200);
 App route has been hit. 200
 ===========================
 ```
+
+## Version bumping
+To use the utility tool's version bump it must be used with a task manager.
+```javascript
+utility.bumpit(currentV, tag);
+```
+The method takes in two parameters where currentV is a string of the current semantic version and 3 different tags: MAJOR MINOR PATCH

--- a/src/server.js
+++ b/src/server.js
@@ -24,3 +24,45 @@ exports.debug = (msg, status) => {
     }
   }
 };
+
+exports.bumpit = (currentV, tag) => {
+  const tagComp = tag.toUpperCase();
+
+  // Format version string into an array
+  const updateV = currentV.split('.');
+
+  // Make sure version string is only numbers
+  if (currentV.match(/^[a-z]+$/)) {
+    throw error;
+  } else {
+    // Check tag strings for semver versioning Vmajor.minor.patch
+    if (tagComp === 'MAJOR') {
+      // v+MAJOR.0.0
+      updateV[0]++;
+
+      // Reset other semver values to '0'
+      updateV[1] = 0;
+      updateV[2] = 0;
+
+      return updateV.join('.');
+    } else if (tagComp === 'MINOR') {
+      // v0.+MINOR.0
+      updateV[1]++;
+
+      // Reset other semver values to '0'
+      updateV[0] = 0;
+      updateV[2] = 0;
+
+      return updateV.join('.');
+    } else if (tagComp === 'PATCH') {
+      // v0.0.+PATCH
+      updateV[2]++;
+
+      // Reset other semver values to '0'
+      updateV[0] = 0;
+      updateV[1] = 0;
+
+      return updateV.join('.');
+    }
+  }
+};

--- a/test/__log.js
+++ b/test/__log.js
@@ -10,7 +10,7 @@ describe('Console log', () => {
     logger(utility.debug('Logging'));
     expect(logger.callCount).to.equal(1);
   });
-
+  // FIXME: remove unnecessary test
   it('Should be able to append to a file', (done) => {
       let append = sinon.spy();
       append(fs.appendFile('logs/output.log', "Test output", () => {}));

--- a/test/__version_bump.js
+++ b/test/__version_bump.js
@@ -1,0 +1,32 @@
+const bump = require('../src/server');
+const expect = require('chai').expect;
+
+// Unit test for version bumping
+describe('VERSION BUMP TEST: ', () => {
+  it('should test the MAJOR bump', (done) => {
+    const tag = 'major';
+    const currentV = '1.0.0';
+    const bumpit = bump.bumpit(currentV, tag);
+
+    expect(bumpit).to.be.a('String');
+    done();
+  });
+
+  it('should test the MINOR bump', (done) => {
+    const currentV = '0.0.0';
+    const tag = 'minor';
+    const bumpit = bump.bumpit(currentV, tag);
+
+    expect(bumpit).to.be.a('String');
+    done();
+  });
+
+  it('should test the PATCH bump', (done) => {
+    const currentV = '0.0.0';
+    const tag = 'patch';
+    const bumpit = bump.bumpit(currentV, tag);
+
+    expect(bumpit).to.be.a('String');
+    done();
+  });
+});


### PR DESCRIPTION
ADD: version bump method bumpit()
ADD: unit test for version bump
bumpit(currentV, tag) where currentV is the string of the projects current semantic version, and 'tag' is either: MAJOR, MINOR, PATCH string input.
ADD: section in readme on how to use it.
